### PR TITLE
FIX: A bug with multiple host_routes not getting parsed correctly.

### DIFF
--- a/lib/puppet/provider/neutron_subnet/neutron.rb
+++ b/lib/puppet/provider/neutron_subnet/neutron.rb
@@ -82,11 +82,10 @@ Puppet::Type.type(:neutron_subnet).provide(
   def self.parse_host_routes(values)
     host_routes = []
     return [] if values.empty? or values == '[]'
-    # Strip brackets from output, needed after neutronclient >= 6.1.0
-    values = values.gsub('[', '').gsub(']', '')
-    for value in Array(values)
-      host_route = JSON.parse(value.gsub(/\\"/,'"').gsub('u\'', '"')
+    values = JSON.parse(values.gsub(/\\"/,'"').gsub('u\'', '"')
                               .gsub('\'','"'))
+
+    for host_route in values
       nexthop = host_route['nexthop']
       destination = host_route['destination']
       host_routes << "destination=#{destination},nexthop=#{nexthop}"

--- a/spec/unit/provider/neutron_subnet/neutron_spec.rb
+++ b/spec/unit/provider/neutron_subnet/neutron_spec.rb
@@ -232,4 +232,19 @@ tenant_id="60f9544eb94c42a6b7e8e98c2be981b1"'
       provider.enable_dhcp=('False')
     end
   end
+
+  describe 'can parse one and more host_routes' do
+    one_host_routes = "[{u\'destination\': u\'12.0.0.0/24\', u\'nexthop\': u\'10.0.0.1\'}]"
+    two_host_routes = "[{u\'destination\': u\'12.0.0.0/24\', u\'nexthop\': u\'10.0.0.1\'}, {u\'destination\': u\'12.0.0.99/24\', u\'nexthop\': u\'10.0.0.99\'}]"
+
+    result_one_route = ["destination=12.0.0.0/24,nexthop=10.0.0.1"]
+    result_two_routes = ["destination=12.0.0.0/24,nexthop=10.0.0.1", "destination=12.0.0.99/24,nexthop=10.0.0.99"]
+
+    [ [one_host_routes, result_one_route], [two_host_routes, result_two_routes]].each { |i, o|
+      it "should call parse_host_routes with #{o.length} routes" do
+        results = provider_class.parse_host_routes(i)
+        expect(results).to eql(o)
+      end
+    }
+  end
 end


### PR DESCRIPTION
    Current multiple host_routes would cause a parse error when getting
    parsed by parse_host_routes(). This fix ensures multiple host_routes
    are being parsed correctly and returned.

    Added spectest shows that the changes fixes the issue at hand.