### PR TITLE
Fix: Race Condition In Dynamic Networking Setup

### DIFF
--- a/lib/puppet/provider/neutron_network/openstack.rb
+++ b/lib/puppet/provider/neutron_network/openstack.rb
@@ -54,24 +54,29 @@ Puppet::Type.type(:neutron_network).provide(
 
   def self.prefetch(resources)
     # NOTE{mohido}: fixes race condition between loading and reading networks (dynamic networks)
-    retries = 0
-    begin
-      networks = instances
-    rescue Exception => e
-      Puppet::Util::Warnings.warnonce "Fetching networks failed, trying again..."
-      retries += 1
-      if (retries <= 5)
-        sleep(5)
-        retry
+    self.do_not_manage = true
+    request('network', 'list').collect do |attrs|
+      if found = resources.find{ |name, resource| name == attrs[:name] }
+        _, resource = found
+        network = request('network', 'show', attrs[:id])
+        resource.provider = new(
+          :ensure                    => :present,
+          :name                      => attrs[:name],
+          :id                        => attrs[:id],
+          :admin_state_up            => network[:admin_state_up],
+          :provider_network_type     => network[:provider_network_type],
+          :provider_physical_network => network[:provider_physical_network],
+          :provider_segmentation_id  => network[:provider_segmentation_id],
+          :router_external           => network[:router_external],
+          :shared                    => network[:shared],
+          :tenant_id                 => network[:project_id],
+          :project_id                => network[:project_id],
+          :availability_zone_hint    => parse_availability_zone_hint(network[:availability_zone_hints]),
+          :mtu                       => network[:mtu],
+        )
       end
-      raise "Could not load networks: #{e.message}"
     end
-
-    resources.keys.each do |name|
-      if provider = networks.find{ |net| net.name == name }
-        resources[name].provider = provider
-      end
-    end
+    self.do_not_manage = false
   end
 
   def exists?

--- a/lib/puppet/provider/neutron_network/openstack.rb
+++ b/lib/puppet/provider/neutron_network/openstack.rb
@@ -53,7 +53,20 @@ Puppet::Type.type(:neutron_network).provide(
   end
 
   def self.prefetch(resources)
-    networks = instances
+    # NOTE{mohido}: fixes race condition between loading and reading networks (dynamic networks)
+    retries = 0
+    begin
+      networks = instances
+    rescue Exception => e
+      Puppet::Util::Warnings.warnonce "Fetching networks failed, trying again..."
+      retries += 1
+      if (retries <= 5)
+        sleep(5)
+        retry
+      end
+      raise "Could not load networks: #{e.message}"
+    end
+
     resources.keys.each do |name|
       if provider = networks.find{ |net| net.name == name }
         resources[name].provider = provider

--- a/lib/puppet/provider/neutron_subnet/openstack.rb
+++ b/lib/puppet/provider/neutron_subnet/openstack.rb
@@ -56,7 +56,20 @@ Puppet::Type.type(:neutron_subnet).provide(
   end
 
   def self.prefetch(resources)
-    subnets = instances
+    # NOTE{mohido}: fixes race condition between loading and reading networks (dynamic networks)
+    retries = 0
+    begin
+      networks = instances
+    rescue Exception => e
+      Puppet::Util::Warnings.warnonce "Fetching subnets failed, trying again..."
+      retries += 1
+      if (retries <= 5)
+        sleep(5)
+        retry
+      end
+      raise "Could not load subnets: #{e.message}"
+    end
+
     resources.keys.each do |name|
       if provider = subnets.find{ |subnet| subnet.name == name }
         resources[name].provider = provider

--- a/lib/puppet/provider/neutron_subnet/openstack.rb
+++ b/lib/puppet/provider/neutron_subnet/openstack.rb
@@ -57,24 +57,32 @@ Puppet::Type.type(:neutron_subnet).provide(
 
   def self.prefetch(resources)
     # NOTE{mohido}: fixes race condition between loading and reading networks (dynamic networks)
-    retries = 0
-    begin
-      networks = instances
-    rescue Exception => e
-      Puppet::Util::Warnings.warnonce "Fetching subnets failed, trying again..."
-      retries += 1
-      if (retries <= 5)
-        sleep(5)
-        retry
+    self.do_not_manage = true
+    request('subnet', 'list').collect do |attrs|
+      if found = resources.find{ |name, resource| name == attrs[:name] }
+        _, resource = found
+        subnet = request('subnet', 'show', attrs[:id])
+        resource.provider = new(
+        :ensure            => :present,
+        :name              => attrs[:name],
+        :id                => attrs[:id],
+        :cidr              => subnet[:cidr],
+        :ip_version        => subnet[:ip_version],
+        :ipv6_ra_mode      => subnet[:ipv6_ra_mode],
+        :ipv6_address_mode => subnet[:ipv6_address_mode],
+        :gateway_ip        => parse_gateway_ip(subnet[:gateway_ip]),
+        :allocation_pools  => parse_allocation_pool(subnet[:allocation_pools]),
+        :host_routes       => parse_host_routes(subnet[:host_routes]),
+        :dns_nameservers   => parse_dns_nameservers(subnet[:dns_nameservers]),
+        :enable_dhcp       => subnet[:enable_dhcp],
+        :network_id        => subnet[:network_id],
+        :network_name      => get_network_name(subnet[:network_id]),
+        :tenant_id         => subnet[:project_id],
+        :project_id        => subnet[:project_id],
+      )
       end
-      raise "Could not load subnets: #{e.message}"
     end
-
-    resources.keys.each do |name|
-      if provider = subnets.find{ |subnet| subnet.name == name }
-        resources[name].provider = provider
-      end
-    end
+    self.do_not_manage = false
   end
 
   def self.parse_gateway_ip(value)


### PR DESCRIPTION
# Summary
The OpenStack provider tries to fetch all networks and subnets regardless of the given parameters. If networks are being created and deleted frequently, a race condition can happen where:
1. the puppet provider requests an `openstack network list`
2. user requests an `openstack network delete`
3. the puppet provider throws error when requesting an `openstack network show`

# Fix Explained
Instead of fetching all networks, we can just add providers to the "resourced" networks/subnets passed as argument.